### PR TITLE
fix :开放iframe沙盒限制“allow-scripts”

### DIFF
--- a/docs/md/zh/entity/vc-entity.md
+++ b/docs/md/zh/entity/vc-entity.md
@@ -132,6 +132,7 @@
         console.log(entity)
         if (entity) {
           this.frame = this.viewer.infoBox.frame
+          this.frame.setAttribute('sandbox','allow-same-origin allow-popups allow-forms allow-scripts')
           this.frame.contentWindow.addEventListener('click', this.frameClick)
         } else {
           this.frame && this.frame.contentWindow.removeEventListener('click', this.frameClick)


### PR DESCRIPTION
规避点击时，浏览器报“about:blank:1 Blocked script execution in 'about:blank' because the document's frame is sandboxed and the 'allow-scripts' permission is not set” 主要开放iframe的sandbox沙箱限制