### PR TITLE
fix: :bug: VcZoomControl:可选参数安全访问

### DIFF
--- a/packages/components/controls/zoom-control/use-zoom-control.ts
+++ b/packages/components/controls/zoom-control/use-zoom-control.ts
@@ -81,7 +81,7 @@ export default function (props, { emit }, vcInstance: VcComponentInternalInstanc
           const movementVector = Cartesian3.multiplyByScalar(direction, relativeAmount, direction)
           const endPosition = Cartesian3.add(focus, movementVector, focus)
           const type = relativeAmount < 1 ? 'zoomIn' : 'zoomOut'
-          const target = e.currentTarget
+          const target = e && e?.currentTarget
           const level = heightToLevel(camera.positionCartographic.height).toFixed(0)
           const listener = getInstanceListener(vcInstance, 'zoomEvt')
           listener &&


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow VueCesium's contributing guide [English](https://github.com/zouyaoji/vue-cesium/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/zouyaoji/vue-cesium/blob/master/.github/CONTRIBUTING.zh-CN.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.

Repaired the secure access of Zoom optional parameters, 
causing the exposed zoomIn and zoomOut functions to be unable to execute code in sequence for scaling. 
Checked zoomReset, which functions normally.

修复了zoom可选参数安全访问，
暴露出的放大和缩小功能受此影响无法顺序执行代码进行缩放。
同时检查了zoomReset，功能正常。