### PR TITLE
chore: remove preinstall script and specify pnpm in package.json and husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx lint-staged
+pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "docs:serve": "pnpm run -C docs serve",
     "stub": "pnpm run -r --parallel stub",
     "prepare": "husky",
-    "preinstall": "npx only-allow pnpm -y",
     "postinstall": "pnpm stub && concurrently \"pnpm gen:version\" \"pnpm run -C internal/metadata dev\""
   },
   "author": "zouyaoji <370681295@qq.com>",
@@ -127,5 +126,15 @@
     "vue": "^3.5.33",
     "vue-jest": "5.0.0-alpha.10",
     "vue-tsc": "^3.1.4"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow VueCesium's contributing guide [English](https://github.com/zouyaoji/vue-cesium/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/zouyaoji/vue-cesium/blob/master/.github/CONTRIBUTING.zh-CN.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.


## only-allow has been deprecated


only-allow deprecated notice:  https://github.com/pnpm/only-allow#readme
about devengines: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines

## sometimes it cannot recognize pnpm correctly

```
ray@ray-PC:~/Documents/code/out/vue-cesium$ pnpm install
Scope: all 12 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
. preinstall$ npx only-allow pnpm -y
│ npm warn Unknown project config "shamefully-hoist". This will stop working in the next major version of npm. See `npm help npmrc` for…
│ npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm. See `npm help np…
│ npm warn Unknown project config "shell-emulator". This will stop working in the next major version of npm. See `npm help npmrc` for s…
│ ╔═════════════════════════════════════════════════════════════╗
│ ║                                                             ║
│ ║   Use "pnpm install" for installation in this project.      ║
│ ║                                                             ║
│ ║   If you don't have pnpm, install it via "npm i -g pnpm".   ║
│ ║   For more details, go to https://pnpm.io/                  ║
│ ║                                                             ║
│ ╚═════════════════════════════════════════════════════════════╝
└─ Failed in 5.7s at /home/ray/Documents/code/out/vue-cesium
[ELIFECYCLE] Command failed with exit code 1.
```

## Updated Husky configs

as devEngines.packageManager breaks npx validation.